### PR TITLE
Fix Set Flags and WG6 Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,41 +69,7 @@
             <artifactId>worldguard</artifactId>
             <version>6.0.0-SNAPSHOT</version>
             <type>jar</type>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>truezip</artifactId>
-                    <groupId>de.schlichtherle</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>prtree</artifactId>
-                    <groupId>org.khelekore</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>opencsv</artifactId>
-                    <groupId>net.sf.opencsv</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>junit</artifactId>
-                    <groupId>junit</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>js</artifactId>
-                    <groupId>rhino</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jchronic</artifactId>
-                    <groupId>com.sk89q</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>iconomy</artifactId>
-                    <groupId>com.nijikokun</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>commandbook</artifactId>
-                    <groupId>com.sk89q</groupId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <distributionManagement>

--- a/src/main/java/com/mewin/WGCustomFlags/PluginListener.java
+++ b/src/main/java/com/mewin/WGCustomFlags/PluginListener.java
@@ -168,7 +168,7 @@ public class PluginListener implements Listener
                 && map.containsKey("settype")
                 && map.get("settype") instanceof Map)
         {
-            Flag tmpFlag = getFlag("type_" + name, (Map) map.get("setttype"));
+            Flag tmpFlag = getFlag("type_" + name, (Map) map.get("settype"));
             newFlag = new CustomSetFlag(name, tmpFlag);
         }
         else if (type.equalsIgnoreCase("enum")

--- a/src/main/java/com/mewin/util/Util.java
+++ b/src/main/java/com/mewin/util/Util.java
@@ -10,9 +10,12 @@ import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.RegionGroup;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.bukkit.Location;
@@ -318,6 +321,8 @@ public final class Util
         }
         else
         {
+            List<ProtectedRegion> regionList = new ArrayList<ProtectedRegion>();
+            regionList.add(region);
             HashSet<Object> allowedValues = (HashSet<Object>) region.getFlag(allowFlag);
             HashSet<Object> blockedValues = (HashSet<Object>) region.getFlag(denyFlag);
             
@@ -340,7 +345,7 @@ public final class Util
                         allowedValues = null;
                     }
                 }
-                else if (!group.contains(player.getAssociation(region)))
+                else if (!group.contains(player.getAssociation(regionList)))
                 {
                     allowedValues = null;
                 }
@@ -366,7 +371,7 @@ public final class Util
                         blockedValues = null;
                     }
                 }
-                else if (!group.contains(player.getAssociation(region)))
+                else if (!group.contains(player.getAssociation(regionList)))
                 {
                     blockedValues = null;
                 }


### PR DESCRIPTION
This contains my fix from the master branch for reading set flags out of a flags.yml file, and also a fix that seems to be necessary to work with the latest WG - though I'm not entirely sure how it was building before.

From what I can tell, getAssociation now takes a List<ProtectedRegion>.